### PR TITLE
Specify library maintainer in metadata

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Sodaq_LPS22HB
 version=1.0.0
 author=Alex Tsamakos,SODAQ
-maintainer=
+maintainer=SODAQ
 sentence=An Arduino library for the LPS22HB sensor.
 paragraph=Supports barometric and temperature sensors.
 category=Sensors


### PR DESCRIPTION
In order to be [specification](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format) compliant, the `maintainer` field of library.properties must specify the maintainer of the library.